### PR TITLE
port upstream v1.1.0–v1.4.0: hooks, compaction summary, trust auto-co…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "pi-autoresearch-skill",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Autonomous experiment loop for Claude Code. Port of davebcn87/pi-autoresearch — try an idea, measure it, keep what works, discard what doesn't, repeat.",
   "owner": {
     "name": "Ronald",

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -7,9 +7,9 @@ This repo is a **port**, not a fork, of [`davebcn87/pi-autoresearch`](https://gi
 | Field | Value |
 |---|---|
 | Upstream repo | `https://github.com/davebcn87/pi-autoresearch` |
-| Pinned commit | `5a29db080131449edc6d25a6b351b12879063366` |
-| Short SHA | `5a29db0` |
-| Ported on | `2026-04-18` |
+| Pinned commit | `84232861a09e753f63bceda46852f0ddbb4c9afd` |
+| Short SHA | `8423286` |
+| Ported on | `2026-05-12` |
 | Upstream license | MIT |
 
 When updating, bump `Pinned commit` and `Ported on`, and add a row to the changelog at the bottom of this file.
@@ -21,6 +21,9 @@ When updating, bump `Pinned commit` and `Ported on`, and add a row to the change
 | `extensions/pi-autoresearch/` (pi extension with TS tools) | `plugins/autoresearch/` (Claude Code plugin) |
 | `skills/autoresearch-create/` (pi skill) | `plugins/autoresearch/skills/autoresearch/SKILL.md` |
 | `skills/autoresearch-finalize/` (pi skill) | `plugins/autoresearch/skills/autoresearch-finalize/SKILL.md` |
+| `skills/autoresearch-hooks/` (pi skill) | `plugins/autoresearch/skills/autoresearch-hooks/SKILL.md` |
+| `extensions/pi-autoresearch/hooks.ts` (auto-invoked by pi) | `scripts/run-hook.sh` (agent invokes manually in the loop) |
+| `extensions/pi-autoresearch/compaction.ts` (`session_before_compact`) | `scripts/compact-summary.py` (agent invokes before/after compaction) |
 | `skills/autoresearch-finalize/finalize.sh` (uses Node.js) | `plugins/autoresearch/skills/autoresearch-finalize/finalize.sh` (ported to python3) |
 | Tool: `init_experiment` | "Starting a session" section of `SKILL.md` |
 | Tool: `run_experiment` | `bash autoresearch.sh` via Bash tool |
@@ -57,3 +60,4 @@ A GitHub Action (`.github/workflows/check-upstream.yml`) runs this weekly and op
 | Date | This version | Upstream SHA | Notes |
 |---|---|---|---|
 | 2026-04-18 | 0.1.0 | `5a29db0` | Initial port. Skill + session-file contract + helper scripts. |
+| 2026-05-12 | 0.2.0 | `8423286` | Catch-up to upstream v1.4.0. **Ported:** v1.1.0 hooks (new `autoresearch-hooks` skill, `run-hook.sh` wrapper, adapted examples), v1.2.0 trust auto-compaction (added "Long-running loops and context" section), v1.3.0 deterministic compaction summary (`compact-summary.py`). **N/A for Claude Code:** v1.0.1 (pi resume-timer / `/off` abort / `patternProperties` schema / dashboard shortcut fixes — pi-extension-specific), v1.4.0 (configurable pi dashboard shortcuts — pi UI-specific). Hook examples adapted to our status names (`kept`/`reverted`/`failed`/`checks_failed`) and absence of an `asi` sub-object in `autoresearch.jsonl`. |

--- a/plugins/autoresearch/.claude-plugin/plugin.json
+++ b/plugins/autoresearch/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autoresearch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Autonomous experiment loop for Claude Code. Iteratively optimizes a measurable metric by hypothesizing, benchmarking, and keeping only improvements. Ported from davebcn87/pi-autoresearch.",
   "author": {
     "name": "Ronald"

--- a/plugins/autoresearch/skills/autoresearch-hooks/SKILL.md
+++ b/plugins/autoresearch/skills/autoresearch-hooks/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: autoresearch-hooks
+description: Optional before/after hooks that fire at iteration boundaries in an autoresearch session. Use when the user wants to extend the loop with research lookups, notifications, anti-thrash steering, or learnings journaling without modifying the main skill. Triggers when the user mentions "autoresearch hook", "before each iteration", "after each run", "notify on best", "auto-tag", or similar lifecycle automation.
+license: MIT
+---
+
+# autoresearch-hooks
+
+Optional scripts that the autoresearch loop calls at iteration boundaries. Two hooks, both invoked by the agent (via `scripts/autoresearch/run-hook.sh`) — their effect is a file on disk or stdout that the agent reads on the next turn.
+
+```
+autoresearch.hooks/
+  before.sh    # fires before each iteration (prospective)
+  after.sh     # fires after each log.sh call (retrospective)
+```
+
+Both files are optional. Files without the executable bit are silently ignored.
+
+---
+
+## Lifecycle
+
+The main `autoresearch` skill invokes hooks via the wrapper `bash scripts/autoresearch/run-hook.sh before|after` at two points per iteration:
+
+1. **Before** — right before the hypothesize step. Wrapper synthesizes input JSON from session files (`autoresearch.md` for goal, `autoresearch.jsonl` for last_run / best_metric / baseline_metric / run_count) and pipes it to `autoresearch.hooks/before.sh`.
+2. **After** — right after `log.sh` appends the new run. Wrapper reads the just-appended jsonl line as `run_entry` and pipes the same `session` shape.
+
+If the hook prints to stdout, the agent treats it as a steer for the next decision. Empty stdout = silent.
+
+## Contract
+
+### Stdin — `before.sh`
+
+One JSON line. Parse with `jq`. Realistic example:
+
+```json
+{
+  "event": "before",
+  "cwd": "/path/to/workdir",
+  "next_run": 6,
+  "last_run": {
+    "run": 5,
+    "status": "reverted",
+    "metric": 42.1,
+    "description": "Simplified to sorted(arr) — copy cost dominates",
+    "metrics": { "coverage": 94.2 }
+  },
+  "session": {
+    "metric_name": "duration",
+    "metric_unit": "s",
+    "direction": "lower",
+    "baseline_metric": 40.7,
+    "best_metric": 33.5,
+    "run_count": 5,
+    "goal": "Make the test suite faster"
+  }
+}
+```
+
+| Field | Notes |
+|---|---|
+| `last_run` | Most recent jsonl line. `null` on a fresh session. |
+| `last_run.status` | One of `baseline`, `kept`, `reverted`, `failed`, `checks_failed`. |
+| `last_run.metrics` | Optional secondary-metrics object (the 4th arg to `log.sh`). |
+| `session.direction` | `"lower"` or `"higher"` — derived from `autoresearch.config.json` or defaults to `"lower"`. |
+| `session.baseline_metric` | First (`baseline`) run's metric. `null` until the baseline is logged. |
+| `session.best_metric` | Best metric across `kept` runs only. `null` until one is kept. |
+| `session.goal` | First H1 heading in `autoresearch.md`. |
+| `session.run_count` | Total runs logged so far (any status). |
+
+### Stdin — `after.sh`
+
+```json
+{
+  "event": "after",
+  "cwd": "/path/to/workdir",
+  "run_entry": {
+    "run": 6,
+    "status": "reverted",
+    "metric": 38.9,
+    "description": "Timsort hybrid slower on random",
+    "metrics": {}
+  },
+  "session": { /* same shape as before.sh, post-run */ }
+}
+```
+
+### Output
+
+- **Stdout** (up to 8 KB by convention) — delivered to the agent as a steer message. Empty = silent.
+- **Non-zero exit** — surfaced as an error steer. Don't fail the loop on it.
+- **Timeouts** — wrapper enforces a 30 s soft timeout via `timeout 30`.
+
+### Preservation across revert
+
+`autoresearch.hooks/**` matches the `autoresearch.*` glob and is preserved by the loop's `git checkout -- .` revert step. See the main skill's revert rules.
+
+> **Status-name note.** Upstream pi uses `keep` / `discard`; this Claude Code port uses `kept` / `reverted` / `failed` / `checks_failed`. Examples here use the port's names. If you adapt a script from the upstream repo, translate accordingly.
+
+---
+
+## Examples
+
+Reference scripts live under `examples/`. They're not policy — copy, adapt, mark executable.
+
+- `examples/before/` — `anti-thrash.sh`, `context-rotation.sh`, `external-search.sh`, `hypothesis-reflection.sh`, `idea-rotator.sh`, `qmd-search.sh`
+- `examples/after/` — `auto-tag-winners.sh`, `learnings-journal.sh`, `macos-notify.sh`
+
+---
+
+## Steps to add a hook
+
+1. **Understand the session.** Read `autoresearch.md` for the objective and metric; glance at `autoresearch.sh` for the workload. Your hook should complement the loop, not duplicate it.
+
+2. **Clarify the user's intent.** What should happen, at which boundary? Research before / journaling after / notify on wins / intervene on thrash.
+
+3. **Start from an example** closest to the intent. If nothing fits, write from scratch following the same style (named constants, short functions, guard clauses, JSON stdin parsed with `jq`).
+
+4. **Copy, adapt, mark executable.**
+
+   ```bash
+   mkdir -p autoresearch.hooks
+   cp "${CLAUDE_PLUGIN_ROOT}/skills/autoresearch-hooks/examples/before/external-search.sh" \
+      autoresearch.hooks/before.sh
+   chmod +x autoresearch.hooks/before.sh
+   ```
+
+5. **Sanity-test with a piped mock** before relying on it in the loop:
+
+   ```bash
+   jq -n '{
+     event:"before", cwd:".", next_run:1, last_run:null,
+     session:{metric_name:"duration", metric_unit:"s", direction:"lower",
+              baseline_metric:null, best_metric:null, run_count:0, goal:"test"}
+   }' | ./autoresearch.hooks/before.sh
+   ```
+
+6. **Commit the hook** with other session files. The revert glob preserves it across iterations.
+
+---
+
+## Rules of thumb
+
+- **Read what the agent actually writes** — `description`, `metric`, `status`, `metrics`. The Claude Code port has no `asi` sub-object; do not invent fields and instruct the agent to populate them.
+- **Silent is the default.** Only print to stdout when you have something useful. Empty stdout = no steer.
+- **Guard with early exits.** `[ -z "$query" ] && exit 0` is cheaper and clearer than nested `if`.
+- **One concern per script.** Research + learnings? Use both `before.sh` and `after.sh`. Don't bundle.
+- **No environment variables.** Everything is on stdin; extract with `jq`. There is no `$AUTORESEARCH_WORK_DIR`.

--- a/plugins/autoresearch/skills/autoresearch-hooks/examples/after/auto-tag-winners.sh
+++ b/plugins/autoresearch/skills/autoresearch-hooks/examples/after/auto-tag-winners.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Tag every new best with a sortable git tag so `git log --tags` becomes
+# a progression record. Pure side effect — no steer.
+
+set -euo pipefail
+
+readonly TAG_PREFIX="autoresearch/best-run"
+
+is_new_best() {
+  local status="$1" metric="$2" best="$3"
+  [ "$status" = "kept" ] && [ -n "$best" ] && [ "$metric" = "$best" ]
+}
+
+tag_name_for() {
+  local run="$1" metric="$2"
+  printf '%s-%s-%s' "$TAG_PREFIX" "$run" "$(printf '%g' "$metric")"
+}
+
+write_tag() {
+  git -C "$1" tag -f "$2" >/dev/null
+}
+
+input="$(cat)"
+status=$(jq -r '.run_entry.status' <<<"$input")
+metric=$(jq -r '.run_entry.metric' <<<"$input")
+best=$(jq -r '.session.best_metric // empty' <<<"$input")
+
+is_new_best "$status" "$metric" "$best" || exit 0
+
+workdir=$(jq -r '.cwd' <<<"$input")
+run=$(jq -r '.run_entry.run' <<<"$input")
+write_tag "$workdir" "$(tag_name_for "$run" "$metric")"

--- a/plugins/autoresearch/skills/autoresearch-hooks/examples/after/learnings-journal.sh
+++ b/plugins/autoresearch/skills/autoresearch-hooks/examples/after/learnings-journal.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Append one human-readable line per run to a file that survives revert
+# and accumulates across sessions. Pure side effect — no steer.
+
+set -euo pipefail
+
+readonly LEARNINGS_FILE="autoresearch.learnings.md"
+
+run_number()      { jq -r '.run_entry.run' <<<"$1"; }
+run_status()      { jq -r '.run_entry.status' <<<"$1"; }
+run_metric()      { jq -r '.run_entry.metric' <<<"$1"; }
+run_description() { jq -r '.run_entry.description // "-"' <<<"$1"; }
+
+append_journal_line() {
+  local file="$1" run="$2" status="$3" metric="$4" desc="$5"
+  printf 'run=%s status=%s metric=%s desc=%s\n' "$run" "$status" "$metric" "$desc" >> "$file"
+}
+
+input="$(cat)"
+file="$(jq -r '.cwd' <<<"$input")/$LEARNINGS_FILE"
+
+append_journal_line "$file" \
+  "$(run_number "$input")" \
+  "$(run_status "$input")" \
+  "$(run_metric "$input")" \
+  "$(run_description "$input")"

--- a/plugins/autoresearch/skills/autoresearch-hooks/examples/after/macos-notify.sh
+++ b/plugins/autoresearch/skills/autoresearch-hooks/examples/after/macos-notify.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Fires a native macOS banner (and optional steer) only on milestone runs.
+# Uses osascript, which is built into macOS. For other platforms swap to
+# terminal-notifier, notify-send (Linux), or a webhook curl.
+
+set -euo pipefail
+
+readonly TITLE="🏆 autoresearch: new best"
+
+is_new_best() {
+  local status="$1" metric="$2" best="$3"
+  [ "$status" = "kept" ] && [ -n "$best" ] && [ "$metric" = "$best" ]
+}
+
+send_mac_notification() {
+  osascript -e "display notification \"$1\" with title \"$TITLE\"" >/dev/null
+}
+
+input="$(cat)"
+status=$(jq -r '.run_entry.status' <<<"$input")
+metric=$(jq -r '.run_entry.metric' <<<"$input")
+best=$(jq -r '.session.best_metric // empty' <<<"$input")
+name=$(jq -r '.session.metric_name' <<<"$input")
+unit=$(jq -r '.session.metric_unit // ""' <<<"$input")
+
+is_new_best "$status" "$metric" "$best" || exit 0
+
+body="$name = $metric$unit"
+send_mac_notification "$body"
+echo "🏆 New best: $body"

--- a/plugins/autoresearch/skills/autoresearch-hooks/examples/before/anti-thrash.sh
+++ b/plugins/autoresearch/skills/autoresearch-hooks/examples/before/anti-thrash.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# After N consecutive non-improvements, emit a steer suggesting a structural rethink.
+# Counts any non-kept status (reverted/failed/checks_failed) in the recent window.
+
+set -euo pipefail
+
+readonly WINDOW_SIZE=5
+readonly STREAK_THRESHOLD=5
+
+recent_non_improvements() {
+  tail -n "$WINDOW_SIZE" "$1" 2>/dev/null \
+    | jq -r 'select(.status != "kept" and .status != "baseline") | .run' \
+    | wc -l | tr -d ' '
+}
+
+thrash_suggestions() {
+  echo "⚠️ $1 consecutive non-improvements. Consider:"
+  echo "  - Re-reading autoresearch.md and the benchmark script"
+  echo "  - Trying something structurally different, not another variation"
+  echo "  - Measuring what the CPU is actually spending time on"
+}
+
+input="$(cat)"
+jsonl="$(jq -r '.cwd' <<<"$input")/autoresearch.jsonl"
+[ -f "$jsonl" ] || exit 0
+streak=$(recent_non_improvements "$jsonl")
+
+[ "$streak" -lt "$STREAK_THRESHOLD" ] && exit 0
+thrash_suggestions "$streak"

--- a/plugins/autoresearch/skills/autoresearch-hooks/examples/before/context-rotation.sh
+++ b/plugins/autoresearch/skills/autoresearch-hooks/examples/before/context-rotation.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# When autoresearch.md exceeds a size threshold, keep the preamble and
+# archive the tail. Prevents session-document bloat from eating context.
+
+set -euo pipefail
+
+readonly MAX_BYTES=$((20 * 1024))
+readonly KEEP_LINES=80
+
+file_too_large() {
+  [ "$(wc -c < "$1")" -gt "$MAX_BYTES" ]
+}
+
+archive_tail() {
+  local file="$1" archive="${1%.md}.archive.md"
+  tail -n +$((KEEP_LINES + 1)) "$file" >> "$archive"
+  head -n "$KEEP_LINES" "$file" > "$file.tmp"
+  mv "$file.tmp" "$file"
+}
+
+input="$(cat)"
+md="$(jq -r '.cwd' <<<"$input")/autoresearch.md"
+[ -f "$md" ] && file_too_large "$md" || exit 0
+
+archive_tail "$md"
+echo "Rotated autoresearch.md (kept first $KEEP_LINES lines, archived rest)."

--- a/plugins/autoresearch/skills/autoresearch-hooks/examples/before/external-search.sh
+++ b/plugins/autoresearch/skills/autoresearch-hooks/examples/before/external-search.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Infers a query from the agent's natural notes and fetches external material.
+# Swap the search-cli call for any tool you have: an MCP client, a CLI over
+# a documentation index, a curl to a search API, a web-search wrapper.
+
+set -euo pipefail
+
+readonly RESEARCH_FILE="autoresearch.research.md"
+readonly RESULT_LIMIT=5
+
+query_from_agent_notes() {
+  # The Claude Code port logs `description` and `session.goal`; there is no
+  # `asi` sub-object in autoresearch.jsonl.
+  jq -r '
+    .last_run.description //
+    .session.goal //
+    empty
+  ' <<<"$1"
+}
+
+fetch_results() {
+  # Replace with your search tool of choice.
+  search-cli "$1" -n "$RESULT_LIMIT"
+}
+
+input="$(cat)"
+query=$(query_from_agent_notes "$input")
+[ -z "$query" ] && exit 0
+
+workdir="$(jq -r '.cwd' <<<"$input")"
+fetch_results "$query" > "$workdir/$RESEARCH_FILE"
+echo "Research saved → $RESEARCH_FILE (query: $query)"

--- a/plugins/autoresearch/skills/autoresearch-hooks/examples/before/hypothesis-reflection.sh
+++ b/plugins/autoresearch/skills/autoresearch-hooks/examples/before/hypothesis-reflection.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# After a non-improvement, ask a cheap model to critique the failed attempt.
+# Swap llm-cli for any short-prompt CLI (claude, llama-cli, ollama,
+# a local endpoint via curl, etc.).
+
+set -euo pipefail
+
+readonly MODEL="claude-haiku-4-5"
+
+fired_on_non_improvement() {
+  local s
+  s="$(jq -r '.last_run.status // empty' <<<"$1")"
+  [ "$s" = "reverted" ] || [ "$s" = "failed" ] || [ "$s" = "checks_failed" ]
+}
+
+critique_prompt() {
+  local desc="$1" status="$2"
+  printf 'The attempt "%s" was %s.\n' "$desc" "$status"
+  printf 'Name two adjacent directions that might work instead. One sentence each.'
+}
+
+ask_model() {
+  llm-cli --model "$MODEL" --prompt "$1"
+}
+
+input="$(cat)"
+fired_on_non_improvement "$input" || exit 0
+
+desc=$(jq -r '.last_run.description // "unknown"' <<<"$input")
+status=$(jq -r '.last_run.status' <<<"$input")
+ask_model "$(critique_prompt "$desc" "$status")"

--- a/plugins/autoresearch/skills/autoresearch-hooks/examples/before/idea-rotator.sh
+++ b/plugins/autoresearch/skills/autoresearch-hooks/examples/before/idea-rotator.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# If autoresearch.ideas.md exists, surface the top unchecked bullet
+# as a steer nudge. Format assumes markdown checkboxes: `- [ ] idea`.
+
+set -euo pipefail
+
+readonly IDEAS_FILE="autoresearch.ideas.md"
+readonly UNCHECKED_PATTERN='^- \[ \]'
+
+first_unchecked_idea() {
+  grep -m1 -E "$UNCHECKED_PATTERN" "$1" | sed 's/^- \[ \] //'
+}
+
+input="$(cat)"
+ideas="$(jq -r '.cwd' <<<"$input")/$IDEAS_FILE"
+[ -f "$ideas" ] || exit 0
+
+next=$(first_unchecked_idea "$ideas")
+[ -z "$next" ] && exit 0
+echo "Next idea from $IDEAS_FILE: $next"

--- a/plugins/autoresearch/skills/autoresearch-hooks/examples/before/qmd-search.sh
+++ b/plugins/autoresearch/skills/autoresearch-hooks/examples/before/qmd-search.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Same shape as external-search but targets a local qmd collection:
+# a BM25 / vector / rerank index over your project's markdown.
+# Useful for private or project-specific corpora (design docs, ADRs,
+# runbooks, past postmortems).
+#
+# One-time setup: qmd collection add <path> --name <name>
+# See https://www.npmjs.com/package/qmd
+
+set -euo pipefail
+
+readonly DOCS_FILE="autoresearch.docs.md"
+readonly RESULT_LIMIT=5
+
+query_from_agent_notes() {
+  jq -r '
+    .last_run.description //
+    .session.goal //
+    empty
+  ' <<<"$1"
+}
+
+fetch_docs() {
+  qmd query "$1" -n "$RESULT_LIMIT"
+}
+
+input="$(cat)"
+query=$(query_from_agent_notes "$input")
+[ -z "$query" ] && exit 0
+
+workdir="$(jq -r '.cwd' <<<"$input")"
+fetch_docs "$query" > "$workdir/$DOCS_FILE"
+echo "Docs saved → $DOCS_FILE (query: $query)"

--- a/plugins/autoresearch/skills/autoresearch/SKILL.md
+++ b/plugins/autoresearch/skills/autoresearch/SKILL.md
@@ -29,7 +29,13 @@ Five files live in the **project root** and make the loop resumable across conte
 | `autoresearch.sh` | Benchmark script. Must emit `METRIC name=value` lines. |
 | `autoresearch.checks.sh` | *(optional)* Correctness backpressure — tests, types, lint. Runs after every passing benchmark. |
 | `autoresearch.ideas.md` | *(optional)* Ideas backlog for complex/deferred hypotheses. |
-| `autoresearch.config.json` | *(optional)* Session config — `maxIterations`, `workingDir`. |
+| `autoresearch.config.json` | *(optional)* Session config — `maxIterations`, `workingDir`, `direction`, `metricName`, `metricUnit`. |
+| `autoresearch.hooks/before.sh` | *(optional)* Hook run before each iteration. See the `autoresearch-hooks` skill. |
+| `autoresearch.hooks/after.sh` | *(optional)* Hook run after each `log.sh` call. See the `autoresearch-hooks` skill. |
+
+All `autoresearch.*` paths (including `autoresearch.hooks/**`) survive the loop's revert step.
+
+> **Note on `jq`.** `run-hook.sh` needs `jq` on PATH to build the hook input JSON. If `jq` is missing, the hook is silently skipped. Install with `brew install jq` / `apt install jq`.
 
 Helper scripts (copy into project once with `install-into-project.sh`):
 
@@ -38,6 +44,8 @@ Helper scripts (copy into project once with `install-into-project.sh`):
 | `log.sh` | Append a run to `autoresearch.jsonl` |
 | `results.sh` | Print a results table |
 | `bench-template.sh` | Starting template for `autoresearch.sh` |
+| `run-hook.sh` | Invoke `autoresearch.hooks/{before,after}.sh` with synthesized JSON stdin |
+| `compact-summary.py` | Print a deterministic 6-section summary for resuming after context compaction |
 
 ## First-time project setup
 
@@ -158,13 +166,23 @@ Create in the project root to configure session behaviour:
 |---|---|
 | `workingDir` | Override the directory for all autoresearch file I/O, command execution, and git operations. Absolute or relative to the session cwd. Fails if the directory doesn't exist. |
 | `maxIterations` | Maximum experiments before stopping. Useful for cost control on long-running loops. |
+| `direction` | `"lower"` or `"higher"`. Used by `results.sh`, `run-hook.sh`, and `compact-summary.py` to identify the best metric. Defaults to `"lower"`. |
+| `metricName` | Display name for the primary metric (e.g. `"duration"`). Used by hooks and the compaction summary. |
+| `metricUnit` | Display unit (e.g. `"s"`, `"ms"`, `"KB"`). Used by hooks and the compaction summary. |
 
 ## The loop
 
 **LOOP FOREVER. Never ask "should I continue?" — the user expects autonomous work. NEVER STOP until interrupted.**
 
+### 0. Before-hook (optional)
+If `autoresearch.hooks/before.sh` exists and is executable, run:
+```bash
+bash scripts/autoresearch/run-hook.sh before
+```
+Its stdout is a steer for this iteration — read it before hypothesizing. Silent output = nothing to do.
+
 ### 1. Hypothesize
-Pick one specific change. Consult "What's Been Tried" and `autoresearch.ideas.md`. State the hypothesis in one sentence.
+Pick one specific change. Consult "What's Been Tried", `autoresearch.ideas.md`, and any output from the before-hook. State the hypothesis in one sentence.
 
 ### 2. Implement
 Make the change. Keep the diff focused — one idea per run. Respect constraints and off-limits boundaries.
@@ -198,6 +216,13 @@ bash scripts/autoresearch/log.sh "<metric_value>" "<kept|reverted|failed|checks_
 ```
 The fourth argument is optional JSON for secondary metrics. Omit it if not tracking secondaries.
 
+### 5b. After-hook (optional)
+If `autoresearch.hooks/after.sh` exists and is executable, run:
+```bash
+bash scripts/autoresearch/run-hook.sh after
+```
+Its stdout (if any) is context for the next iteration.
+
 ### 6. Update autoresearch.md
 Append a line to **What's Been Tried**. If the idea is a dead end (regressed or has a structural reason to fail), note it with a one-line reason so future iterations don't repeat it.
 
@@ -222,6 +247,18 @@ Immediately begin the next iteration. **Do not pause for confirmation.** If the 
 - **Think longer when stuck.** Re-read source files, study output, reason about what the CPU is actually doing. The best ideas come from deep understanding, not random variations.
 - **Crashes:** fix if trivial, otherwise log and move on. Don't over-invest.
 - **Branch isolation.** Each session runs on its own branch. Never run on `main`.
+
+## Long-running loops and context
+
+Claude Code auto-compacts when context fills — trust it. Don't budget tokens or predict your own next iteration's footprint.
+
+When a compaction window is imminent (or when starting a fresh session on an existing branch), run:
+
+```bash
+python3 scripts/autoresearch/compact-summary.py
+```
+
+It prints a deterministic six-section markdown block (Session / Experiment Rules / Ideas Backlog / Recent Runs / Next Step) that embeds `autoresearch.md` and `autoresearch.ideas.md` and tails the last 50 runs from `autoresearch.jsonl`. A resuming agent reading that summary has everything needed to continue — no need to re-read the source files.
 
 ## Viewing progress
 

--- a/plugins/autoresearch/skills/autoresearch/scripts/compact-summary.py
+++ b/plugins/autoresearch/skills/autoresearch/scripts/compact-summary.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Deterministic compaction summary for an autoresearch session.
+
+Reads the session files in the current working directory and prints a
+six-section markdown block to stdout. Run this **before** Claude Code
+auto-compacts (or right after resuming a session) to seed a fresh
+context with everything needed to keep iterating.
+
+The output mirrors upstream pi-autoresearch's `compaction.ts` summary so
+that anyone reading either codebase's session sees the same shape.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+RECENT_RUN_LIMIT = 50
+
+
+def load_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    out: list[dict] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            pass
+    return out
+
+
+def load_config(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def read_text(path: Path) -> str:
+    return path.read_text() if path.exists() else ""
+
+
+def best_of(runs: list[dict], direction: str) -> dict | None:
+    kept = [r for r in runs if r.get("status") == "kept" and "metric" in r]
+    if not kept:
+        return None
+    reverse = direction == "higher"
+    return sorted(kept, key=lambda r: r["metric"], reverse=reverse)[0]
+
+
+def baseline_of(runs: list[dict]) -> dict | None:
+    for r in runs:
+        if r.get("status") == "baseline":
+            return r
+    return None
+
+
+def fmt_metric(value, unit: str) -> str:
+    if value is None:
+        return "—"
+    return f"{value}{unit}" if unit else f"{value}"
+
+
+def fmt_delta(value, baseline, direction: str) -> str:
+    if value is None or baseline is None or baseline == 0:
+        return ""
+    pct = (value - baseline) / abs(baseline) * 100
+    sign = "+" if pct >= 0 else ""
+    arrow = ""
+    if direction == "lower":
+        arrow = " ✓" if pct < 0 else " ✗"
+    elif direction == "higher":
+        arrow = " ✓" if pct > 0 else " ✗"
+    return f" ({sign}{pct:.1f}%{arrow})"
+
+
+def goal_from_md(text: str) -> str:
+    for line in text.splitlines():
+        if line.startswith("# "):
+            return line[2:].removeprefix("Autoresearch: ").strip()
+    return ""
+
+
+def status_counts(runs: list[dict]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for r in runs:
+        s = r.get("status", "?")
+        counts[s] = counts.get(s, 0) + 1
+    return counts
+
+
+def main() -> int:
+    cwd = Path(os.getcwd())
+    runs = load_jsonl(cwd / "autoresearch.jsonl")
+    config = load_config(cwd / "autoresearch.config.json")
+    md_text = read_text(cwd / "autoresearch.md")
+    ideas_text = read_text(cwd / "autoresearch.ideas.md")
+
+    direction = config.get("direction", "lower")
+    metric_name = config.get("metricName", "metric")
+    metric_unit = config.get("metricUnit", "")
+    goal = goal_from_md(md_text)
+
+    baseline = baseline_of(runs)
+    best = best_of(runs, direction)
+    counts = status_counts(runs)
+
+    out: list[str] = []
+    out.append("# Autoresearch Compaction Summary\n")
+
+    out.append("## Session")
+    out.append(f"- **Goal**: {goal or '—'}")
+    out.append(
+        f"- **Metric**: {metric_name} ({metric_unit or 'unitless'}, {direction} is better)"
+    )
+    if counts:
+        joined = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+        out.append(f"- **Runs**: {len(runs)} ({joined})")
+    else:
+        out.append("- **Runs**: 0")
+    if baseline:
+        out.append(f"- **Baseline**: {fmt_metric(baseline.get('metric'), metric_unit)}")
+    if best:
+        delta = fmt_delta(
+            best.get("metric"), baseline.get("metric") if baseline else None, direction
+        )
+        out.append(
+            f"- **Best**: {fmt_metric(best.get('metric'), metric_unit)}{delta} (run {best.get('run')})"
+        )
+    out.append("")
+
+    out.append("## Experiment Rules (autoresearch.md)")
+    out.append(md_text.strip() or "_(missing)_")
+    out.append("")
+
+    out.append("## Ideas Backlog (autoresearch.ideas.md)")
+    out.append(ideas_text.strip() or "_(empty)_")
+    out.append("")
+
+    recent = runs[-RECENT_RUN_LIMIT:]
+    out.append(f"## Recent Runs (last {len(recent)})")
+    base_metric = baseline.get("metric") if baseline else None
+    for r in recent:
+        delta = (
+            ""
+            if r.get("status") == "baseline"
+            else fmt_delta(r.get("metric"), base_metric, direction)
+        )
+        out.append(
+            f"- #{r.get('run')} {r.get('status')} "
+            f"{fmt_metric(r.get('metric'), metric_unit)}{delta} | "
+            f"{r.get('description', '')}"
+        )
+    out.append("")
+
+    out.append("## Next Step")
+    out.append(
+        "Pick the most promising hypothesis from the ideas backlog or the latest "
+        "descriptions in recent runs, then run `bash autoresearch.sh` + "
+        "`bash scripts/autoresearch/log.sh ...`. Do not re-read `autoresearch.md` "
+        "or `autoresearch.jsonl` — this summary already embeds them."
+    )
+
+    print("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/autoresearch/skills/autoresearch/scripts/install-into-project.sh
+++ b/plugins/autoresearch/skills/autoresearch/scripts/install-into-project.sh
@@ -10,15 +10,21 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 mkdir -p scripts/autoresearch
-cp "$SCRIPT_DIR/log.sh"            scripts/autoresearch/log.sh
-cp "$SCRIPT_DIR/results.sh"        scripts/autoresearch/results.sh
-cp "$SCRIPT_DIR/bench-template.sh" scripts/autoresearch/bench-template.sh
-chmod +x scripts/autoresearch/*.sh
+cp "$SCRIPT_DIR/log.sh"             scripts/autoresearch/log.sh
+cp "$SCRIPT_DIR/results.sh"         scripts/autoresearch/results.sh
+cp "$SCRIPT_DIR/results.py"         scripts/autoresearch/results.py
+cp "$SCRIPT_DIR/bench-template.sh"  scripts/autoresearch/bench-template.sh
+cp "$SCRIPT_DIR/run-hook.sh"        scripts/autoresearch/run-hook.sh
+cp "$SCRIPT_DIR/compact-summary.py" scripts/autoresearch/compact-summary.py
+chmod +x scripts/autoresearch/*.sh scripts/autoresearch/compact-summary.py
 
 echo "✅ autoresearch scripts installed at scripts/autoresearch/"
 echo "   - scripts/autoresearch/log.sh"
 echo "   - scripts/autoresearch/results.sh"
+echo "   - scripts/autoresearch/results.py"
 echo "   - scripts/autoresearch/bench-template.sh"
+echo "   - scripts/autoresearch/run-hook.sh"
+echo "   - scripts/autoresearch/compact-summary.py"
 echo ""
 echo "Commit these so future sessions on other machines have everything they need:"
 echo "   git add scripts/autoresearch && git commit -m 'add autoresearch helper scripts'"

--- a/plugins/autoresearch/skills/autoresearch/scripts/results.py
+++ b/plugins/autoresearch/skills/autoresearch/scripts/results.py
@@ -35,8 +35,10 @@ def format_table(runs, direction):
     best_metric = find_best(runs, direction)
     lines = []
     lines.append("")
-    lines.append(f"  {'Run':>4}  {'Status':<13}  {'Metric':>10}  {'Commit':<8}  Description")
-    lines.append(f"  {'-'*4}  {'-'*13}  {'-'*10}  {'-'*8}  {'-'*30}")
+    lines.append(
+        f"  {'Run':>4}  {'Status':<13}  {'Metric':>10}  {'Commit':<8}  Description"
+    )
+    lines.append(f"  {'-' * 4}  {'-' * 13}  {'-' * 10}  {'-' * 8}  {'-' * 30}")
     for r in runs:
         is_best = (
             best_metric is not None
@@ -61,7 +63,10 @@ def format_table(runs, direction):
 
 def main():
     if len(sys.argv) != 3:
-        print(f"usage: {sys.argv[0]} <path/to/autoresearch.jsonl> <lower|higher>", file=sys.stderr)
+        print(
+            f"usage: {sys.argv[0]} <path/to/autoresearch.jsonl> <lower|higher>",
+            file=sys.stderr,
+        )
         sys.exit(2)
 
     path, direction = sys.argv[1], sys.argv[2]

--- a/plugins/autoresearch/skills/autoresearch/scripts/run-hook.sh
+++ b/plugins/autoresearch/skills/autoresearch/scripts/run-hook.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Invoke autoresearch.hooks/{before,after}.sh with a synthesized JSON stdin.
+#
+# Usage:
+#   run-hook.sh before          # before next iteration (uses last jsonl line as last_run)
+#   run-hook.sh after           # after log.sh (uses last jsonl line as run_entry)
+#
+# Exits 0 silently if the hook file is missing or not executable, mirroring
+# the upstream pi-autoresearch contract.
+
+set -euo pipefail
+
+STAGE="${1:-}"
+case "$STAGE" in
+  before|after) ;;
+  *) echo "usage: $(basename "$0") before|after" >&2; exit 2 ;;
+esac
+
+HOOK="autoresearch.hooks/${STAGE}.sh"
+[ -x "$HOOK" ] || exit 0
+
+command -v jq >/dev/null 2>&1 || { echo "run-hook: jq is required" >&2; exit 0; }
+
+JSONL="autoresearch.jsonl"
+MD="autoresearch.md"
+CONFIG="autoresearch.config.json"
+CWD="$(pwd)"
+
+# --- session block --------------------------------------------------------
+direction="lower"
+metric_name="metric"
+metric_unit=""
+goal=""
+
+if [ -f "$CONFIG" ]; then
+  direction=$(jq -r '.direction // "lower"' "$CONFIG")
+  metric_name=$(jq -r '.metricName // "metric"' "$CONFIG")
+  metric_unit=$(jq -r '.metricUnit // ""' "$CONFIG")
+fi
+if [ -f "$MD" ]; then
+  goal=$(grep -m1 '^# ' "$MD" 2>/dev/null | sed 's/^# *Autoresearch: *//; s/^# *//' || true)
+fi
+
+run_count=0
+baseline_metric=null
+best_metric=null
+last_line=""
+if [ -f "$JSONL" ]; then
+  run_count=$(wc -l < "$JSONL" | tr -d ' ')
+  baseline_metric=$(jq -r 'select(.status=="baseline") | .metric' "$JSONL" 2>/dev/null | head -n1)
+  [ -z "$baseline_metric" ] && baseline_metric=null
+  if [ "$direction" = "higher" ]; then
+    best_metric=$(jq -r 'select(.status=="kept") | .metric' "$JSONL" 2>/dev/null | sort -g | tail -n1)
+  else
+    best_metric=$(jq -r 'select(.status=="kept") | .metric' "$JSONL" 2>/dev/null | sort -g | head -n1)
+  fi
+  [ -z "$best_metric" ] && best_metric=null
+  last_line=$(tail -n1 "$JSONL" 2>/dev/null || true)
+fi
+
+session=$(jq -n \
+  --arg name "$metric_name" \
+  --arg unit "$metric_unit" \
+  --arg dir "$direction" \
+  --argjson baseline "$baseline_metric" \
+  --argjson best "$best_metric" \
+  --argjson count "$run_count" \
+  --arg goal "$goal" \
+  '{metric_name:$name, metric_unit:$unit, direction:$dir,
+    baseline_metric:$baseline, best_metric:$best,
+    run_count:$count, goal:$goal}')
+
+# --- event-specific block -------------------------------------------------
+if [ "$STAGE" = "before" ]; then
+  next_run=$((run_count + 1))
+  if [ -n "$last_line" ]; then
+    last_run="$last_line"
+  else
+    last_run="null"
+  fi
+  payload=$(jq -n \
+    --arg cwd "$CWD" \
+    --argjson next "$next_run" \
+    --argjson last "$last_run" \
+    --argjson session "$session" \
+    '{event:"before", cwd:$cwd, next_run:$next, last_run:$last, session:$session}')
+else
+  if [ -z "$last_line" ]; then
+    # Nothing to report on; skip silently.
+    exit 0
+  fi
+  payload=$(jq -n \
+    --arg cwd "$CWD" \
+    --argjson entry "$last_line" \
+    --argjson session "$session" \
+    '{event:"after", cwd:$cwd, run_entry:$entry, session:$session}')
+fi
+
+# --- invoke ---------------------------------------------------------------
+# 30s soft timeout via `timeout` if available; otherwise run directly.
+if command -v timeout >/dev/null 2>&1; then
+  printf '%s\n' "$payload" | timeout 30 "$HOOK"
+else
+  printf '%s\n' "$payload" | "$HOOK"
+fi

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -4,12 +4,24 @@ import tempfile
 import unittest
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "plugins/autoresearch/skills/autoresearch/scripts"))
+sys.path.insert(
+    0,
+    str(
+        Path(__file__).parent.parent
+        / "plugins/autoresearch/skills/autoresearch/scripts"
+    ),
+)
 from results import find_best, format_table, load_runs
 
 
 def make_run(run, status, metric, description="test", commit="abc1234"):
-    return {"run": run, "status": status, "metric": metric, "description": description, "commit": commit}
+    return {
+        "run": run,
+        "status": status,
+        "metric": metric,
+        "description": description,
+        "commit": commit,
+    }
 
 
 def write_jsonl(runs):
@@ -41,11 +53,19 @@ class TestLoadRuns(unittest.TestCase):
 
 class TestFindBest(unittest.TestCase):
     def test_lower_is_better(self):
-        runs = [make_run(1, "baseline", 42.3), make_run(2, "kept", 39.1), make_run(3, "reverted", 45.0)]
+        runs = [
+            make_run(1, "baseline", 42.3),
+            make_run(2, "kept", 39.1),
+            make_run(3, "reverted", 45.0),
+        ]
         self.assertEqual(find_best(runs, "lower"), 39.1)
 
     def test_higher_is_better(self):
-        runs = [make_run(1, "baseline", 0.7), make_run(2, "kept", 0.85), make_run(3, "reverted", 0.6)]
+        runs = [
+            make_run(1, "baseline", 0.7),
+            make_run(2, "kept", 0.85),
+            make_run(3, "reverted", 0.6),
+        ]
         self.assertEqual(find_best(runs, "higher"), 0.85)
 
     def test_only_baseline_counts(self):


### PR DESCRIPTION
…mpaction

Catch up to upstream 8423286 (v1.4.0). Bumps plugin + marketplace to 0.2.0.

Ported:
- v1.1.0 hooks → new autoresearch-hooks skill with run-hook.sh wrapper (synthesizes the upstream hook-input JSON from our session files since Claude Code has no extension to drive hooks for us) and 9 adapted example scripts under examples/{before,after}/.
- v1.2.0 trust auto-compaction → new "Long-running loops and context" section in the main SKILL.md.
- v1.3.0 deterministic compaction summary → compact-summary.py, prints the same six sections as upstream's compaction.ts.

Hook examples were adapted to the port's status names (kept/reverted/failed/checks_failed) and the absence of an `asi` sub-object in autoresearch.jsonl.

N/A for the Claude Code port (documented in UPSTREAM.md changelog):
- v1.0.1 fixes (pi resume-timer, /off abort, patternProperties schema, dashboard shortcut mnemonics) — pi-extension-specific.
- v1.4.0 configurable dashboard shortcuts — pi UI-specific.

Closes #1.